### PR TITLE
Update date format to use 24hr based on locale.

### DIFF
--- a/WeatherGroundServer.xm
+++ b/WeatherGroundServer.xm
@@ -51,8 +51,10 @@
         [self changeLabelTextWithAttributedString:temperatureAttrString];
 
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-            NSDateFormatter *formatter = [NSDateFormatter new];
-			formatter.dateFormat = @"HH:mm";
+            		NSString *format = [NSDateFormatter dateFormatFromTemplate:@"j" options:0 locale:[NSLocale currentLocale]];
+            		BOOL is24Hour = ([format rangeOfString:@"a"].location == NSNotFound);
+            		NSDateFormatter *formatter = [NSDateFormatter new];
+			formatter.dateFormat = [NSString stringWithFormat:@"%@:mm", (is24Hour ? "HH" : "hh")];
 			NSString *currentStatusTime = [formatter stringFromDate:[NSDate now]];
 
 			self.statusStringView.attributedText = nil;


### PR DESCRIPTION
Current implementation uses a blanket `HH` date format (24h) which is incorrect, as many users/locales default to a 12 hour format (`hh`).  This fix bases the format on the current locale set, however it would be better to directly check or listen to changes in the system preferences.